### PR TITLE
DSA-4-Product-of-Array-Except-Self

### DIFF
--- a/ProductOfArraryExceptSelf.py
+++ b/ProductOfArraryExceptSelf.py
@@ -1,0 +1,29 @@
+# Checking Product
+def productExceptSelf(nums):
+    n = len(nums)
+    # Initialize the left and right product arrays
+    left = [1] * n
+    right = [1] * n
+    answer = [1] * n
+
+    # Fill the left array
+    for i in range(1, n):
+        left[i] = left[i - 1] * nums[i - 1]
+
+    # Fill the right array
+    for i in range(n - 2, -1, -1):
+        right[i] = right[i + 1] * nums[i + 1]
+
+    # Construct the answer array
+    for i in range(n):
+        answer[i] = left[i] * right[i]
+
+    return answer
+
+# Input of num_1 and num_2
+num_1 = [1, 2, 3, 4]
+num_2 = [-1,1,0,-3,3]
+
+# Printing OutPut
+print(productExceptSelf(num_1))  
+print(productExceptSelf(num_2)) 


### PR DESCRIPTION
Given an integer array nums, return an array answer such that answer[i] is equal to the product of all the elements of nums except nums[i]. 

The product of any prefix or suffix of nums is guaranteed to fit in a 32-bit integer. 

You must write an algorithm that runs in O(n) time and without using the division operation. 


Example 1: 

Input: nums = [1,2,3,4] Output: [24,12,8,6] Example 2: 

Input: nums = [-1,1,0,-3,3] Output: [0,0,9,0,0] 

Constraints: 

2 <= nums.length <= 10^5 

-30 <= nums[i] <= 30 

The product of any prefix or suffix of nums is guaranteed to fit in a 32-bit integer.